### PR TITLE
Patch to support this syntax « background: transparent url("...") no-repeat; »

### DIFF
--- a/spritecss/finder.py
+++ b/spritecss/finder.py
@@ -28,7 +28,7 @@ def _bg_positioned(val):
     return False
 
 def _match_background_url(val):
-    mo = bg_url_re.match(val)
+    mo = bg_url_re.search(val)
     if not mo:
         raise NoSpriteFound(val)
     return mo.groups()[0]


### PR DESCRIPTION
Hi,

before this patch, this css instruction wasn't matched :

background: transparent url("mime/7z.png") no-repeat;

This patch fix this bug.

Regards,
Stephane
