### PR TITLE
Last declaration in a block does not require a semicolon

### DIFF
--- a/spritecss/css/parser.py
+++ b/spritecss/css/parser.py
@@ -483,11 +483,9 @@ class CSSParser(EventStream):
         elif lex == "comment_begin":
             return st.sub(self._handle_comment)
         elif lex == "block_end":
-            # this happens when the last declaration isn't terminated properly
-            # NOTE This is really invalid CSS, but we're nice people.
+            # This happens when the last declaration isn't terminated with a
+            # semicolon, which is valid (and often occurs during minimization)
             if st.declaration:
-                raise RuntimeError("unconsumed declaration in %r, "
-                                   "missing semicolon?" % (st,))
                 self.push(Declaration(st))
             self.push(BlockEnd(st))
             return st(handler=None, declaration="", selector="")


### PR DESCRIPTION
Hi,

I've just started using Spritemapper as a part of my assset-building pipeline, and I've run into an issue with its CSS parsing.  It raises a `RuntimeError` when the last declaration in a block is not terminated by a semicolon, but I don't believe that should be an error [according to the spec](http://www.w3.org/TR/CSS21/syndata.html#declaration).

I ran into this because my current pipeline goes

```
Sass compiler => YUI Compressor => Spritemapper
```

and the YUI Compressor always removes the semicolon following the last declaration in a block.  I can probably update my pipeline, but I figured I'd submit this minor pull request in the meantime.  It's minor mostly because the code was already in place to properly handle this case but was hidden behind the `raise RuntimeError...` exception.

There must be some reason that exception was put in place, though, so I'm sorry if I'm wasting your time.  

Thanks for a great project!
