### PR TITLE
Skip unsupported image formats

### DIFF
--- a/spritecss/main.py
+++ b/spritecss/main.py
@@ -46,6 +46,8 @@ class CSSFile(object):
             def test_sref(sref):
                 if not access(str(sref), R_OK):
                     logger.error("%s: not readable", sref); return False
+                if not str(sref).lower().endswith('.png'):
+                    logger.warn('%s: unsupported format', sref); return False
                 else:
                     logger.debug("%s passed", sref); return True
             return self.mapper.map_reduced(ifilter(test_sref, srefs))


### PR DESCRIPTION
This skips unsupported (ie, non-png) image files in two steps:
1. Skip attempting to parse images with non-png extensions
2. Gracefully handle errors from parsing invalid png images (in case some `.png` file is invalid or improperly-named)

I could not figure out how to attach this pull request to the existing issue #10, so I'm basically duplicating it here.  Sorry for the noise!
