### PR TITLE
Partial fix for repeat|repeat-x|repeat-y

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ MANIFEST
 build/*
 dist/*
 spritemapper.egg-info
+/TAGS
+/tags

--- a/main.py
+++ b/main.py
@@ -1,0 +1,3 @@
+import spritecss.main
+
+spritecss.main.main()

--- a/spritecss/finder.py
+++ b/spritecss/finder.py
@@ -11,9 +11,17 @@ from .css import split_declaration
 logger = logging.getLogger(__name__)
 
 bg_url_re = re.compile(r'\s*url\([\'"]?(.*?)[\'"]?\)\s*')
-
 class NoSpriteFound(Exception): pass
 class PositionedBackground(NoSpriteFound): pass
+
+def excluded_repeat(val):
+    result = None
+    for part in val.split():
+        if part in ('repeat', 'repeat-x', 'repeat-y'):
+            return True
+        elif part == 'no-repeat':
+            result = False
+    return result
 
 _pos_names = ("top", "center", "bottom", "right", "middle", "left")
 _pos_units = ("px", "%")

--- a/spritecss/replacer.py
+++ b/spritecss/replacer.py
@@ -4,7 +4,7 @@ import logging
 
 from . import SpriteRef
 from .css import split_declaration
-from .finder import NoSpriteFound, get_background_url
+from .finder import NoSpriteFound, get_background_url, excluded_repeat
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,10 @@ class SpriteReplacer(object):
                 sref = SpriteRef(css.conf.normpath(url),
                                  source=css.fname)
                 try:
-                    new = self._replace_val(css, ev, sref)
+                    if excluded_repeat(val):
+                        new = val
+                    else:
+                        new = self._replace_val(css, ev, sref)
                 except KeyError:
                     new = val
                 ev.declaration = "%s: %s" % (prop, new)

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,3 @@
+* Don't let Spritemapper generate output_image=".png"
+
+* Handle "background-image"?


### PR DESCRIPTION
If a `background` declaration includes `repeat`, `repeat-x`, or `repeat-y`, it is not rewritten by the replacer. The image, however, is still included in the sprite. If the _repeat-style_ is `no-repeat`, the `background` declaration continues to be rewritten, of course.

This is not sufficient if there's an explicit `background-repeat` declaration.

Ideally, there would be more smarts for `repeat-x` and `repeat-y`. See [Stoyan](http://www.phpied.com/background-repeat-and-css-sprites/) for some ideas on how to handle such cases.
